### PR TITLE
fix the loading of the codemirror modules

### DIFF
--- a/lib/inkdrop-rulers.js
+++ b/lib/inkdrop-rulers.js
@@ -1,6 +1,7 @@
 'use babel';
+const path = require('node:path');
 const app = require('@electron/remote').app;
-const modulePath = app.getAppPath() + '/node_modules/'
+const modulePath = path.dirname(app.getAppPath()) + '/node_modules/'
 require(modulePath + 'codemirror/addon/display/rulers.js')
 
 module.exports = {


### PR DESCRIPTION
In Inkdrop v5.6.0 the location of the node_modules folder for loading the packed codemirror addons has changed. Therefore this plugin cannot load the cm addon `codemirror/addon/display/rulers.js`.

Tested on Ubuntu 24.04 and Windows 11